### PR TITLE
Update TOTP Issuer URL to Use `url_origin` from Environment Variables

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -27,10 +27,11 @@ type authHandler struct {
 	authService services.AuthService
 	validator   *validator.Validate
 	jwtConfig   *middlewares.JWTConfig
+	Issuer      string
 }
 
-func NewAuthHandler(logger *slog.Logger, authService services.AuthService, validation *validator.Validate, jwtConfig *middlewares.JWTConfig) AuthHandler {
-	return &authHandler{logger: logger, authService: authService, validator: validation, jwtConfig: jwtConfig}
+func NewAuthHandler(logger *slog.Logger, authService services.AuthService, validation *validator.Validate, jwtConfig *middlewares.JWTConfig, Issuer string) AuthHandler {
+	return &authHandler{logger: logger, authService: authService, validator: validation, jwtConfig: jwtConfig, Issuer: Issuer}
 }
 
 func (ah *authHandler) Login(ctx *fiber.Ctx) error {
@@ -197,7 +198,7 @@ func (ah *authHandler) GenerateOtp(ctx *fiber.Ctx) error {
 	}
 
 	key, err := totp.Generate(totp.GenerateOpts{
-		Issuer:      "localhost:3000",
+		Issuer:      ah.Issuer,
 		AccountName: user.Email,
 		SecretSize:  15,
 	})

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 	"time"
 
 	// "strings"
@@ -64,7 +65,7 @@ func main() {
 	s3Validation := validation.NewS3Validator()
 	publicLinkValidation := validation.NewPublicLinkValidator()
 
-	authHandler := handlers.NewAuthHandler(logger, authService, authValidation, jwtConfig)
+	authHandler := handlers.NewAuthHandler(logger, authService, authValidation, jwtConfig, strings.Split(originURL, ",")[0])
 	pageHandler := handlers.NewPageHandler(s3Service, authService, logger, publikLinkService, jwtConfig)
 	apiHandler := handlers.NewApiHandler(s3Service, logger, s3Validation)
 	publicLinkHandler := handlers.NewPublicLinkHandler(publikLinkService, authService, logger, publicLinkValidation)


### PR DESCRIPTION
This update refactors the TOTP generation logic to retrieve the issuer URL from an environment variable (`url_origin`) instead of the hardcoded `localhost`. The `url_origin` is split by commas, and the first value is used to form the issuer URL. This change ensures better flexibility and configurability for different environments, as the issuer URL can now be dynamically set through environment variables.