### PR TITLE
refactor: update getFileContentType to accept *multipart.FileHeader

### DIFF
--- a/services/s3.go
+++ b/services/s3.go
@@ -91,7 +91,7 @@ func (ss *s3Service) UploadFile(ctx context.Context, bucket, basePath string, fi
 	ss.logger.Debug("Prepared file path", "filename", filename, "fullPath", fullPath)
 
 	// Get the content type using the provided function
-	contentType, err := getFileContentType(file.Filename)
+	contentType, err := getFileContentType(file)
 	if err != nil {
 		ss.logger.Error("Failed to determine content type", "error", err)
 		return fmt.Errorf("failed to determine content type: %w", err)

--- a/services/shared.go
+++ b/services/shared.go
@@ -2,11 +2,11 @@ package services
 
 import (
 	"context"
+	"mime/multipart"
 
 	"log/slog"
 	"mime"
 	"net/http"
-	"os"
 	"path/filepath"
 
 	"github.com/Zenk41/simple-file-web/models"
@@ -49,26 +49,26 @@ func LoadS3Config(s3Data models.ConfigS3) (aws.Config, error) {
 	return cfg, nil
 }
 
-func getFileContentType(filename string) (string, error) {
+func getFileContentType(file *multipart.FileHeader) (string, error) {
 	// First, try to detect by extension
-	ext := filepath.Ext(filename)
+	ext := filepath.Ext(file.Filename)
 	mimeType := mime.TypeByExtension(ext)
 	if mimeType != "" {
-		return mimeType, nil
+			return mimeType, nil
 	}
 
-	// If that fails, try to detect by content
-	file, err := os.Open(filename)
+	// Open the file
+	src, err := file.Open()
 	if err != nil {
-		return "", err
+			return "", err
 	}
-	defer file.Close()
+	defer src.Close()
 
 	// Only the first 512 bytes are used to sniff the content type.
 	buffer := make([]byte, 512)
-	_, err = file.Read(buffer)
+	_, err = src.Read(buffer)
 	if err != nil {
-		return "", err
+			return "", err
 	}
 
 	// Use the net/http package's handy DetectContentType function


### PR DESCRIPTION
- Changed the `getFileContentType` function to use `*multipart.FileHeader` instead of a filename.
- Updated file opening logic to support multipart file handling.
- Removed dependency on `os` package and filepath-based file opening.